### PR TITLE
Adjust TypeScript to generate Node16 module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,6 @@
   "prettier.prettierPath": "./node_modules/prettier",
   "typescript.tsdk": "./node_modules/typescript/lib",
   "typescript.referencesCodeLens.enabled": true,
-  "typescript.implementationsCodeLens.enabled": true
+  "typescript.implementationsCodeLens.enabled": true,
+  "jest.rootPath": "./src"
 }

--- a/__tests__/parsers/profile_parser.test.ts
+++ b/__tests__/parsers/profile_parser.test.ts
@@ -1,5 +1,4 @@
-import { default as bsky } from '@atproto/api'
-const { BskyAgent } = bsky
+import { BskyAgent } from '@atproto/api'
 import * as dotenv from 'dotenv'
 import { parseProfile } from '../../src/parsers/profile_parser'
 

--- a/__tests__/parsers/skeet_parser.test.ts
+++ b/__tests__/parsers/skeet_parser.test.ts
@@ -1,6 +1,4 @@
-import { default as bsky } from '@atproto/api'
-const { BskyAgent } = bsky
-
+import { BskyAgent } from '@atproto/api'
 import * as dotenv from 'dotenv'
 import { parseSkeet } from '../../src/parsers/skeet_parser'
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,16 +1,19 @@
-import type { Config } from '@jest/types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
-const config: Config.InitialOptions = {
+const config: JestConfigWithTsJest = {
   roots: ['<rootDir>/src', '<rootDir>/__tests__'],
-  preset: 'ts-jest/presets/default-esm',
+  modulePaths: ['<rootDir>/src'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
+        tsconfig: 'tsconfig.json',
         useESM: true,
       },
     ],
   },
+  moduleDirectories: ['node_modules'],
+  testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js'],
 }
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "skeeet.xyz",
   "version": "1.0.0",
   "description": "A little helper to convert Skeet links into something readable via iMessage",
-  "type": "module",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "author": "Justin Williams",
   "license": "ISC",
   "scripts": {
@@ -17,8 +14,8 @@
     "lint-fix": "npx eslint --fix -c .eslintrc.json",
     "format": "npx prettier --write './(src|__tests__)/**/*.ts'",
     "format-check": "npx prettier --check './(src|__tests__)/**/*.ts'",
-    "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest",
-    "test-watch": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --watch"
+    "test": "jest",
+    "test-watch": "jest --watch"
   },
   "dependencies": {
     "@atproto/api": "^0.3.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import { default as bsky } from '@atproto/api'
+import * as BlueSky from '@atproto/api'
 import * as dotenv from 'dotenv'
 import express from 'express'
 import { create } from 'express-handlebars'
 import { exit } from 'process'
 import { parseSkeet } from './parsers/skeet_parser.js'
 import { parseProfile } from './parsers/profile_parser.js'
-const { BskyAgent } = bsky
 
 dotenv.config()
 
@@ -22,21 +21,23 @@ app.set('view engine', '.hbs')
 app.use(express.json())
 app.use(express.static('public'))
 
-const agent = new BskyAgent({
+const agent = new BlueSky.BskyAgent({
   service: 'https://bsky.social',
 })
 
-const result = await agent.login({
-  identifier: process.env.BSKY_USERNAME!,
-  password: process.env.BSKY_PASSWORD!,
-})
-
-if (result.success) {
-  console.log('Signed in')
-} else {
-  console.log('Failed to sign in')
-  exit(1)
-}
+agent
+  .login({
+    identifier: process.env.BSKY_USERNAME!,
+    password: process.env.BSKY_PASSWORD!,
+  })
+  .then((result) => {
+    if (result.success) {
+      console.log('Signed in')
+    } else {
+      console.log('Failed to sign in')
+      exit(1)
+    }
+  })
 
 app.post('/api/skeet', async (req, res) => {
   const url = req.body.url as string

--- a/src/parsers/profile_parser.ts
+++ b/src/parsers/profile_parser.ts
@@ -14,7 +14,7 @@ export async function parseProfile(url: string, agent: BskyAgent): Promise<Profi
   const parts = path.split('/')
   const actor = parts[2]
 
-  const profile = await agent.app.bsky.actor.getProfile({ actor: actor })
+  const profile = await agent.getProfile({ actor: actor })
   if (profile.success) {
     const options = {
       displayName: profile.data.displayName,

--- a/src/parsers/skeet_parser.ts
+++ b/src/parsers/skeet_parser.ts
@@ -1,5 +1,4 @@
-import { AppBskyEmbedImages, AppBskyFeedDefs, BskyAgent, default as pkg } from '@atproto/api'
-const { AppBskyFeedPost } = pkg
+import * as BlueSky from '@atproto/api'
 import linkifyStr from 'linkify-string'
 
 type SkeetPayload = {
@@ -12,12 +11,12 @@ type SkeetPayload = {
   avatar: string
   thumb: string | undefined
   link: string
-  images: AppBskyEmbedImages.ViewImage[]
+  images: BlueSky.AppBskyEmbedImages.ViewImage[]
 }
 
 const defaultLang = `en-US`
 
-export async function parseSkeet(url: string, agent: BskyAgent, locale = defaultLang): Promise<SkeetPayload> {
+export async function parseSkeet(url: string, agent: BlueSky.BskyAgent, locale = defaultLang): Promise<SkeetPayload> {
   const parsedUrl = new URL(url)
   const path = parsedUrl.pathname
   const parts = path.split('/')
@@ -38,8 +37,8 @@ export async function parseSkeet(url: string, agent: BskyAgent, locale = default
     depth: 0,
   })
 
-  if (AppBskyFeedPost.validateEntity(post.data)) {
-    const postView = post.data.thread.post as AppBskyFeedDefs.PostView
+  if (BlueSky.AppBskyFeedDefs.validateThreadViewPost(post)) {
+    const postView = post.data.thread.post as BlueSky.AppBskyFeedDefs.PostView
 
     let text = ''
     if ('text' in postView.record) {
@@ -47,15 +46,15 @@ export async function parseSkeet(url: string, agent: BskyAgent, locale = default
     }
     let thumb = ''
     if (postView.embed?.media) {
-      const media = postView.embed?.media as AppBskyEmbedImages.Main
+      const media = postView.embed?.media as BlueSky.AppBskyEmbedImages.Main
       if ('thumb' in media.images[0]) {
         thumb = media.images[0].thumb as string
       }
     }
 
-    let images: AppBskyEmbedImages.ViewImage[] = []
+    let images: BlueSky.AppBskyEmbedImages.ViewImage[] = []
     if (postView.embed?.images) {
-      images = postView.embed?.images as [AppBskyEmbedImages.ViewImage]
+      images = postView.embed?.images as [BlueSky.AppBskyEmbedImages.ViewImage]
       if (images[0] != undefined) {
         thumb = images[0].thumb
       }
@@ -64,7 +63,6 @@ export async function parseSkeet(url: string, agent: BskyAgent, locale = default
     let date: Date | undefined
     let time: Date | undefined
     if ('createdAt' in postView.record) {
-      console.debug(`Post date: ${postView.record.createdAt as Date}`)
       date = new Date(Date.parse(postView.record.createdAt as string))
       time = date
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "nodenext",
+    "module": "Node16",
+    "moduleResolution": "node",
     "baseUrl": "./",
     "composite": true,
     "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,5 @@
     "rootDir": "./src",
     "outDir": "./lib/"
   },
-  "include": ["./src/**/*.ts"],
-  "ts-node": {
-    "esm": true
-  }
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
I am running into a ton of issues with the atproto api package because it only vends off CommonJS which is making my ESM loving life hell. Sometimes the app wont built, but tests will. Sometimes the inverse.

This seems to be a happy medium?